### PR TITLE
refactor: Improve repository info display and file list output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ This is a Go-based Model Context Protocol (MCP) server that provides Git read op
    - Direct Git command execution via `os/exec`
    - Core Git read operations: info, pull, branch listing, enhanced file listing, content reading
    - Pattern-based file filtering with glob support
-   - Character and line counting for text files
+   - File statistics: extension breakdown, file/directory counts
+   - Line counting for text files (bytes shown for size)
    - Multiple file content retrieval with individual error handling
    - Automatic repository name extraction from Git URLs
    - README file discovery with recursive search support
@@ -114,8 +115,9 @@ Tools use consistent parameter naming:
 - The `shouldSkipDirectory()` function handles directory-level pattern matching
 
 **File Information Enhancement:**
-- Character count and line count for text files
-- File size with human-readable formatting (bytes/KB/MB)
+- `list_files` shows files only (no directory entries)
+- File size with human-readable formatting (B/KB/MB)
+- Line count for text files
 - Modification timestamps
 
 **Multiple File Content:**
@@ -151,6 +153,14 @@ Execute operations on multiple repositories in a single call:
 - `batch_clone`: Clone multiple repositories at once
 - `batch_pull`: Pull all (or specified) repositories
 - `batch_status`: Get status of all (or specified) repositories
+
+### Repository Info Output
+
+`get_repository_info` returns a concise overview without commit count (to avoid bias):
+- Branch name, last update, remote URL, license
+- File statistics: total file count, directory count, extension breakdown (top 10)
+- README content (always shown if available)
+- Optional: associated memos with `include_memos=true`
 
 ### Composite Tools
 

--- a/enhanced_features_test.go
+++ b/enhanced_features_test.go
@@ -148,14 +148,9 @@ func TestCharacterCountListFiles(t *testing.T) {
 	}
 
 	for _, file := range files {
-		if !file.IsDir {
-			if expected, exists := testFiles[file.Name]; exists {
-				if file.CharCount != expected.expectedChars {
-					t.Errorf("File %s: expected %d chars, got %d", file.Name, expected.expectedChars, file.CharCount)
-				}
-				if file.LineCount != expected.expectedLines {
-					t.Errorf("File %s: expected %d lines, got %d", file.Name, expected.expectedLines, file.LineCount)
-				}
+		if expected, exists := testFiles[file.Name]; exists {
+			if file.LineCount != expected.expectedLines {
+				t.Errorf("File %s: expected %d lines, got %d", file.Name, expected.expectedLines, file.LineCount)
 			}
 		}
 	}

--- a/git_operations_test.go
+++ b/git_operations_test.go
@@ -50,10 +50,6 @@ func TestGetRepositoryInfo(t *testing.T) {
 				t.Errorf("Expected path %s, got %s", repo.Path, info.Path)
 			}
 
-			if info.CommitCount <= 0 {
-				t.Errorf("Expected positive commit count, got %d", info.CommitCount)
-			}
-
 			if info.CurrentBranch == "" {
 				t.Errorf("Expected current branch to be set")
 			}
@@ -555,8 +551,9 @@ func TestEdgeCases(t *testing.T) {
 			t.Fatalf("Failed to get info for empty repo: %v", err)
 		}
 
-		if info.CommitCount != 0 {
-			t.Errorf("Expected 0 commits in empty repo, got %d", info.CommitCount)
+		// Empty repo should have a valid path
+		if info.Path == "" {
+			t.Errorf("Expected path to be set for empty repo")
 		}
 	})
 }

--- a/performance_test.go
+++ b/performance_test.go
@@ -145,10 +145,10 @@ func TestMemoryUsage(t *testing.T) {
 		}
 
 		elapsed := time.Since(start)
-		t.Logf("Got repository info for %d commits in %v", info.CommitCount, elapsed)
+		t.Logf("Got repository info in %v", elapsed)
 
-		if info.CommitCount <= 3 { // Should have more than initial commits
-			t.Errorf("Expected more commits, got %d", info.CommitCount)
+		if info.Path == "" {
+			t.Errorf("Expected path to be set")
 		}
 
 		if elapsed > 5*time.Second {
@@ -211,8 +211,8 @@ func TestConcurrentOperations(t *testing.T) {
 					errors <- fmt.Errorf("goroutine %d failed: %v", id, err)
 					return
 				}
-				if info.CommitCount <= 0 {
-					errors <- fmt.Errorf("goroutine %d got invalid commit count", id)
+				if info.Path == "" {
+					errors <- fmt.Errorf("goroutine %d got empty path", id)
 					return
 				}
 				done <- true


### PR DESCRIPTION
- Remove commit count from repository info and clone output (avoids bias)
- Add file statistics (extension breakdown, file/dir counts) to get_repository_info
- Show README content by default in repository info
- list_files now shows files only (no directory entries)
- Simplify file info: show size (B/KB/MB) and line count only
- Remove redundant char count (kept bytes for size)
- Update tests and documentation

https://claude.ai/code/session_01RGySKa89curTVLLw2GPPFP