### PR TITLE
Fix README truncation in get_repository_info

### DIFF
--- a/git_operations.go
+++ b/git_operations.go
@@ -954,8 +954,17 @@ func findAndReadReadme(repoPath string) (string, error) {
 	for _, filename := range readmeFiles {
 		path := filepath.Join(repoPath, filename)
 		if _, err := os.Stat(path); err == nil {
-			content, err := GetFileContent(repoPath, filename, 50) // Limit to 50 lines
+			// Count total lines in the README
+			fullPath := filepath.Join(repoPath, filename)
+			_, totalLines := countFileCharacters(fullPath)
+
+			// Get content (no limit to show full README)
+			content, err := GetFileContent(repoPath, filename, 0) // 0 = no limit
 			if err == nil {
+				// If README is very long, add a note about total lines
+				if totalLines > 100 {
+					content += fmt.Sprintf("\n[README: %d lines total]\n", totalLines)
+				}
 				return content, nil
 			}
 		}


### PR DESCRIPTION
- Remove 50-line limit on README display
- Display full README content for get_repository_info tool
- Add total line count indicator for READMEs over 100 lines
- Improves visibility into repository documentation

https://claude.ai/code/session_01SGHh7bTJChxo7hubKopzYx